### PR TITLE
Add Javadoc comments to all methods in the API

### DIFF
--- a/API/src/main/java/net/blitzcube/mlapi/api/IMultiLineAPI.java
+++ b/API/src/main/java/net/blitzcube/mlapi/api/IMultiLineAPI.java
@@ -11,39 +11,147 @@ import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;
 
 /**
- * Created by iso2013 on 5/23/2018.
+ * Represents the core of MultiLineAPI providing various utility methods and functionality
+ * with regards to the API's primary goal.
+ *
+ * @author iso2013
+ * @since May 23rd, 2018
  */
 public interface IMultiLineAPI {
 
+	/**
+	 * Get the tag associated with the specified entity.
+	 *
+	 * @param entity the entity whose tag to retrieve
+	 *
+	 * @return the tag. null if none
+	 */
     ITag getTag(Entity entity);
 
-    ITag createTagIfMissing(Entity entity);
+    /**
+     * Get the tag associated with the specified entity. If no tag has yet been associated,
+     * create one instead.
+     *
+     * @param entity the entity whose tag to retrieve
+     *
+     * @return the created tag
+     */
+    ITag getOrCreateTag(Entity entity);
 
+    /**
+     * Delete the specified entity's tag (if present). If the entity has no tag, this method
+     * will fail silently.
+     *
+     * @param entity the entity whose tag to delete
+     */
     void deleteTag(Entity entity);
 
+    /**
+     * Check whether the specified entity has a tag or not.
+     *
+     * @param entity the entity to check
+     *
+     * @return true if the entity has a tag, false otherwise
+     */
     boolean hasTag(Entity entity);
 
+    /**
+     * Add a default tag controller. Default tag controllers are applied to entity types specified
+     * by {@link ITagController#getAutoApplyFor()}.
+     *
+     * @param controller the controller to add
+     */
     void addDefaultTagController(ITagController controller);
 
+    /**
+     * Remove a default tag controller.
+     *
+     * @param controller the controller to remove
+     */
     void removeDefaultTagController(ITagController controller);
 
+    /**
+     * Get an immutable Set of all default tag controllers.
+     *
+     * @return all default tag controllers
+     */
     Set<ITagController> getDefaultTagControllers();
 
+    /**
+     * Get an immutable Collection of all default tag controllers for the specified entity type
+     *
+     * @param type the type of entity
+     *
+     * @return all default tag controllers
+     */
     Collection<ITagController> getDefaultTagControllers(EntityType type);
 
+    /**
+     * Update an entity's tag for the specified player.
+     *
+     * @param entity the entity whose tag to update
+     * @param target the player for whom to receive the update
+     *
+     * @see #update(Entity)
+     */
     void update(Entity entity, Player target);
 
+    /**
+     * Update an entity's tag for all players
+     *
+     * @param entity the entity whose tag to update
+     *
+     * @see #update(Entity, Player)
+     */
     void update(Entity entity);
 
+    /**
+     * Update a tag controller for the specified player.
+     *
+     * @param controller the controller to update
+     * @param target the player for whom to receive the update
+     *
+     * @see #update(ITagController)
+     */
     void update(ITagController controller, Player target);
 
+    /**
+     * Update a tag controller for all players.
+     *
+     * @param controller the controller to update
+     *
+     * @see #update(ITagController, Player)
+     */
     void update(ITagController controller);
 
+    /**
+     * Update a specific tag line for the specified player.
+     *
+     * @param line the line to update
+     * @param target the player for whom to receive the update
+     *
+     * @see #update(ITagController.TagLine)
+     */
     void update(ITagController.TagLine line, Player target);
 
+    /**
+     * Update a specific tag line for all players.
+     *
+     * @param line the line to update
+     *
+     * @see #update(ITagController.TagLine, Player)
+     */
     void update(ITagController.TagLine line);
 
+    /**
+     * Update all names for the specified player.
+     *
+     * @param target the player for whom to update names
+     */
     void updateNames(Player target);
 
+    /**
+     * Update all names for all players.
+     */
     void updateNames();
 }

--- a/API/src/main/java/net/blitzcube/mlapi/api/tag/ITag.java
+++ b/API/src/main/java/net/blitzcube/mlapi/api/tag/ITag.java
@@ -6,41 +6,148 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 
 /**
- * Created by iso2013 on 5/24/2018.
+ * Represents a dynamic tag over an entity's head.
+ *
+ * @author iso2013
+ * @since May 23rd, 2018
  */
 public interface ITag {
 
+	/**
+	 * Get an immutable List of all tag controllers applied on this tag.
+	 *
+	 * @param sortByLines whether or not to sort by lines
+	 *
+	 * @return all active tag controllers
+	 */
     ImmutableList<ITagController> getTagControllers(boolean sortByLines);
 
+    /**
+     * Add a tag controller to this tag.
+     *
+     * @param controller the controller to add
+     */
     void addTagController(ITagController controller);
 
+    /**
+     * Remove a tag controller from this tag.
+     *
+     * @param controller the controller to remove
+     */
     void removeTagController(ITagController controller);
 
+    /**
+     * Set whether this tag should be visible to the specified player or not.
+     *
+     * @param target the target for whom to update visibility
+     * @param visible the new visibility state
+     */
     void setVisible(Player target, boolean visible);
 
+    /**
+     * Reset the visibility state of this tag to default.
+     *
+     * @param target the target for whom to reset visibility
+     */
     void clearVisible(Player target);
 
+    /**
+     * Check whether this tag is visible to the specified player.
+     *
+     * @param target the target to check
+     *
+     * @return true if visible, false otherwise. null if not explicitly set
+     */
     Boolean isVisible(Player target);
 
+    /**
+     * Get the default value for this tag's visibility.
+     *
+     * @return the default visibility state
+     */
     boolean getDefaultVisible();
 
+    /**
+     * Set the default value for this tag's visibility.
+     *
+     * @param visible the new default visibility state
+     */
     void setDefaultVisible(boolean visible);
 
+    /**
+     * Update this tag for the specified player.
+     *
+     * @param target the target for whom to receive the update
+     *
+     * @see #update()
+     */
     void update(Player target);
 
+    /**
+     * Update this tag for all players.
+     *
+     * @see #update(Player)
+     */
     void update();
 
+    /**
+     * Update this tag for the specified player with respect to the specified tag controller.
+     *
+     * @param controller the controller context with which to update
+     * @param target the target for whom to receive the update
+     *
+     * @see #update(ITagController)
+     */
     void update(ITagController controller, Player target);
 
+    /**
+     * Update this tag for all players with respect to the specified tag controller.
+     *
+     * @param controller the controller context with which to update
+     *
+     * @see #update(ITagController, Player)
+     */
     void update(ITagController controller);
 
+    /**
+     * Update the specific line in this tag for the specified player.
+     *
+     * @param line the line to update
+     * @param target the target for whom to receive the update
+     *
+     * @see #update(ITagController.TagLine)
+     */
     void update(ITagController.TagLine line, Player target);
 
+    /**
+     * Update the specific line in this tag for all players.
+     *
+     * @param line the line to update
+     *
+     * @see #update(ITagController.TagLine, Player)
+     */
     void update(ITagController.TagLine line);
 
+    /**
+     * Update this tag's name for the specified player.
+     *
+     * @param target the target for whom to receive the update
+     *
+     * @see #updateName()
+     */
     void updateName(Player target);
 
+    /**
+     * Update this tag's name for all players.
+     *
+     * @see #updateName(Player)
+     */
     void updateName();
 
+    /**
+     * Get the entity associated with this tag.
+     *
+     * @return the owning entity
+     */
     Entity getTarget();
 }

--- a/API/src/main/java/net/blitzcube/mlapi/api/tag/ITagController.java
+++ b/API/src/main/java/net/blitzcube/mlapi/api/tag/ITagController.java
@@ -8,28 +8,103 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.util.List;
 
 /**
- * Created by iso2013 on 5/24/2018.
+ * Represents a controller for a set of {@link ITag} instances. Controllers may be applied
+ * by default to a select array of entity types (see {@link #getAutoApplyFor()}), or may be
+ * used for one tag in specific (see {@link ITag#addTagController(ITagController)}). This
+ * interface is meant to be implemented in order to further control how tags are processed
+ * and viewed by players in the world.
+ *
+ * @author iso2013
+ * @since May 23rd, 2018
  */
 public interface ITagController {
 
+	/**
+	 * Get a List of tag lines to be shown for the specified entity. The value returned by
+	 * this method should never be modified during the lifetime of a single instance of the
+	 * server. The value should be constant.
+	 *
+	 * @param target the entity for which to retrieve tag lines
+	 *
+	 * @return the lines to display
+	 */
     List<TagLine> getFor(Entity target);
 
+    /**
+     * Get the name to be displayed for the {@code target} with respect to the {@code viewer}.
+     * This method will be called when an entity's tag has been update for any reason.
+     *
+     * @param target the entity for which to retrieve the name
+     * @param viewer the player for whom to retrieve the name
+     * @param previous the name prior to this update invocation
+     *
+     * @return the new name to be displayed
+     */
     default String getName(Entity target, Player viewer, String previous) {
         return previous;
     }
 
+    /**
+     * Get an array of entity types to which this tag controller will be automatically applied.
+     *
+     * @return the entity types
+     */
     EntityType[] getAutoApplyFor();
 
+    /**
+     * Get an instance of the JavaPlugin implementing this controller. Must not be null.
+     *
+     * @return the controlling plugin
+     */
     JavaPlugin getPlugin();
 
+    /**
+     * Get this tag controller's priority. Higher priority controllers are rendered above
+     * lower priority controllers. The higher the integer, the higher the priority. Negative
+     * priorities are supported such that -1 is of a lower priority than 0.
+     *
+     * @return this controller's priority
+     */
     int getPriority();
 
+    /**
+     * Get this tag controller's priority with regards to name updates. Higher priority
+     * controllers are run after lower priority controllers. The higher the integer, the
+     * higher the priority. Negative priorities are supported such that -1 is of a lower
+     * priority than 0.
+     *
+     * @return this controller's name priority
+     */
     int getNamePriority();
 
+    /**
+     * Represents a specific line in a {@link ITag}. A unique implementation of TagLine should
+     * be created for each different line returned in {@link ITagController#getFor(Entity)}.
+     *
+     * @author iso2013
+     * @since May 23rd, 2018
+     */
     interface TagLine {
 
+    	/**
+    	 * Get the text to be displayed over the {@code target}'s head with respect to the
+    	 * {@code viewer}.
+    	 *
+         * @param target the entity for which to retrieve the name
+         * @param viewer the player for whom to retrieve the name
+    	 *
+    	 * @return the text to display
+    	 */
         String getText(Entity target, Player viewer);
 
+        /**
+         * Check whether or not the space should be kept if {@code null} is returned by
+         * {@link #getText(Entity, Player)}.
+         *
+         * @param target the entity for which to check
+         *
+         * @return true if the space should be kept, false if it should be removed
+         */
         boolean keepSpaceWhenNull(Entity target);
     }
 }

--- a/Plugin/src/main/java/net/blitzcube/mlapi/MultiLineAPI.java
+++ b/Plugin/src/main/java/net/blitzcube/mlapi/MultiLineAPI.java
@@ -58,7 +58,7 @@ public final class MultiLineAPI extends JavaPlugin implements IMultiLineAPI {
     }
 
     @Override
-    public Tag createTagIfMissing(Entity entity) {
+    public Tag getOrCreateTag(Entity entity) {
         int id = entity.getEntityId();
 
         if (!tags.containsKey(id)) {

--- a/Plugin/src/main/java/net/blitzcube/mlapi/listener/ServerListener.java
+++ b/Plugin/src/main/java/net/blitzcube/mlapi/listener/ServerListener.java
@@ -124,7 +124,7 @@ public class ServerListener implements Listener {
 
     private void onSpawn(Entity e) {
         if (parent.hasDefaultTagControllers(e.getType())) {
-            this.parent.createTagIfMissing(e);
+            this.parent.getOrCreateTag(e);
         }
     }
 


### PR DESCRIPTION
Added Javadoc comments to as many methods possible. If any are inaccurate, please feel free to correct me and I'll make the required changes.

This pull request also renames IMultiLineAPI#createTagIfMissing() to #getOrCreateTag() as it fits better suits its functionality.